### PR TITLE
Backend feature/signup

### DIFF
--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/config/WebConfig.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/config/WebConfig.java
@@ -10,7 +10,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
     private static final String[] EXCLUDE_PATHS = {
-//            "/users/**",
+            "/users/**",
             "/swagger-ui.html", "/swagger-resources/**", "/webjars/**", "/v2/**"
     };
 

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/controller/UserController.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/controller/UserController.java
@@ -63,5 +63,19 @@ public class UserController {
         }
     }
 
-    
+    @ApiOperation(value = "이메일 중복확인")
+    @GetMapping("/users/check/{email}")
+    public ResponseEntity<?> checkEmail(@PathVariable String email){
+        Map<String,String> map = new HashMap<>();
+        try{
+            if(userService.checkEmail(email)){
+                return new ResponseEntity<>(HttpStatus.CONFLICT);
+            }else{
+                map.put("msg","사용가능한 이메일입니다.");
+                return new ResponseEntity<>(map,HttpStatus.OK);
+            }
+        }catch (Exception e){
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/controller/UserController.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/controller/UserController.java
@@ -6,7 +6,6 @@ import com.halaguys.whistleon.dto.request.UserRegistRequestDto;
 import com.halaguys.whistleon.exception.UnauthorizedException;
 import com.halaguys.whistleon.service.JwtService;
 import com.halaguys.whistleon.service.UserService;
-import com.sun.deploy.net.HttpResponse;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -14,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
-import javax.xml.ws.Response;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -40,16 +38,30 @@ public class UserController {
             map.put("userName",user.getUserName());
             return new ResponseEntity<>(map,HttpStatus.OK);
         }catch (NoSuchElementException | UnauthorizedException e){
+            e.printStackTrace();
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }catch (Exception e){
+            e.printStackTrace();
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
     @ApiOperation(value = "회원가입")
     @PostMapping("/users/signup")
-    public ResponseEntity<String> signUp(@RequestBody UserRegistRequestDto userRegistRequestDto){
-        
-        return null;
+    public ResponseEntity<?> signUp(@RequestBody UserRegistRequestDto userRegistRequestDto){
+        Map<String,String> map = new HashMap<>();
+        try{
+            userService.regist(userRegistRequestDto);
+            map.put("msg","회원가입이 성공하였습니다.");
+            return new ResponseEntity<>(map,HttpStatus.CREATED);
+        }catch (UnauthorizedException e){
+            e.printStackTrace();
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }catch (Exception e) {
+            e.printStackTrace();
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
+
+    
 }

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/domain/user/User.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/domain/user/User.java
@@ -1,12 +1,19 @@
 package com.halaguys.whistleon.domain.user;
 
 import com.halaguys.whistleon.domain.team.Team;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 import javax.persistence.*;
 import java.time.LocalDate;
 
+@DynamicInsert
 @Getter
+@NoArgsConstructor
 @Entity
 public class User {
     @Id @GeneratedValue
@@ -30,18 +37,23 @@ public class User {
     private String location;
 
     @Column(name = "win")
+    @ColumnDefault(value = "0")
     private int win;
 
     @Column(name = "draw")
+    @ColumnDefault(value = "0")
     private int draw;
 
     @Column(name = "lose")
+    @ColumnDefault(value = "0")
     private int lose;
 
     @Column(name = "manner")
+    @ColumnDefault(value = "0")
     private Double manner;
 
     @Column(name = "mvp_count")
+    @ColumnDefault(value = "0")
     private int mvpCount;
 
     /**
@@ -56,5 +68,12 @@ public class User {
     @Column(name = "withdrawl_date")
     private LocalDate withdrawlDate;
 
+    @Builder
+    public User(String userName,String email, String location, String password){
+        this.userName = userName;
+        this.email = email;
+        this.location = location;
+        this.password = password;
+    }
 
 }

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/domain/user/UserRepository.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/domain/user/UserRepository.java
@@ -1,9 +1,10 @@
 package com.halaguys.whistleon.domain.user;
 
+import com.sun.istack.Nullable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Integer> {
-    Optional<User> findAllByEmail(String email);
+    Optional<User> findUserByEmail(String email);
 }

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/dto/request/UserRegistRequestDto.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/dto/request/UserRegistRequestDto.java
@@ -1,4 +1,13 @@
 package com.halaguys.whistleon.dto.request;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public class UserRegistRequestDto {
+    private String email;
+    private String userName;
+    private String password;
+    private String location;
 }

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/service/UserService.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/service/UserService.java
@@ -4,9 +4,12 @@ import com.halaguys.whistleon.domain.user.User;
 import com.halaguys.whistleon.dto.request.UserLoginRequestDto;
 import com.halaguys.whistleon.dto.request.UserRegistRequestDto;
 
+import java.util.Optional;
+
 public interface UserService {
     User login(UserLoginRequestDto userDto);
-    User getUserByEmail(String email);
+    Optional<User> getUserByEmail(String email);
     void matchPassword(String userPassword,String inputPassword);
     void regist(UserRegistRequestDto userDto);
+    boolean checkEmail(String email);
 }

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/service/UserService.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/service/UserService.java
@@ -2,9 +2,11 @@ package com.halaguys.whistleon.service;
 
 import com.halaguys.whistleon.domain.user.User;
 import com.halaguys.whistleon.dto.request.UserLoginRequestDto;
+import com.halaguys.whistleon.dto.request.UserRegistRequestDto;
 
 public interface UserService {
-    User login(UserLoginRequestDto userLoginRequestDto);
+    User login(UserLoginRequestDto userDto);
     User getUserByEmail(String email);
     void matchPassword(String userPassword,String inputPassword);
+    void regist(UserRegistRequestDto userDto);
 }

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/service/UserServiceImpl.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/service/UserServiceImpl.java
@@ -7,7 +7,6 @@ import com.halaguys.whistleon.dto.request.UserRegistRequestDto;
 import com.halaguys.whistleon.exception.UnauthorizedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -20,16 +19,16 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public User login(UserLoginRequestDto userDto) throws NoSuchElementException,UnauthorizedException{
-        User user = getUserByEmail(userDto.getEmail());
-        matchPassword(user.getPassword(),userDto.getPassword());
-        return user;
+        Optional<User> user = getUserByEmail(userDto.getEmail());
+        String password = user.map(User::getPassword)
+                .orElseThrow(NoSuchElementException::new);
+        matchPassword(password,userDto.getPassword());
+        return user.get();
     }
 
-    @Transactional
     @Override
-    public User getUserByEmail(String email) throws NoSuchElementException{
-        return userRepository.findUserByEmail(email)
-                .orElseThrow(NoSuchElementException::new);
+    public Optional<User> getUserByEmail(String email) {
+        return userRepository.findUserByEmail(email);
     }
 
     @Override
@@ -48,5 +47,11 @@ public class UserServiceImpl implements UserService{
                 .password(userDto.getPassword())
                 .build();
         userRepository.save(user);
+    }
+
+    @Override
+    public boolean checkEmail(String email) {
+        return getUserByEmail(email)
+                .isPresent();
     }
 }

--- a/whistle-on-backend/src/main/java/com/halaguys/whistleon/service/UserServiceImpl.java
+++ b/whistle-on-backend/src/main/java/com/halaguys/whistleon/service/UserServiceImpl.java
@@ -3,11 +3,14 @@ package com.halaguys.whistleon.service;
 import com.halaguys.whistleon.domain.user.User;
 import com.halaguys.whistleon.domain.user.UserRepository;
 import com.halaguys.whistleon.dto.request.UserLoginRequestDto;
+import com.halaguys.whistleon.dto.request.UserRegistRequestDto;
 import com.halaguys.whistleon.exception.UnauthorizedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 public class UserServiceImpl implements UserService{
@@ -22,9 +25,10 @@ public class UserServiceImpl implements UserService{
         return user;
     }
 
+    @Transactional
     @Override
     public User getUserByEmail(String email) throws NoSuchElementException{
-        return userRepository.findAllByEmail(email)
+        return userRepository.findUserByEmail(email)
                 .orElseThrow(NoSuchElementException::new);
     }
 
@@ -33,5 +37,16 @@ public class UserServiceImpl implements UserService{
         if(!userPassword.trim().equals(inputPassword.trim())){
             throw new UnauthorizedException();
         }
+    }
+
+    @Override
+    public void regist(UserRegistRequestDto userDto) {
+        User user = User.builder()
+                .userName(userDto.getUserName())
+                .email(userDto.getEmail())
+                .location(userDto.getLocation())
+                .password(userDto.getPassword())
+                .build();
+        userRepository.save(user);
     }
 }

--- a/whistle-on-backend/src/test/java/com/halaguys/whistleon/service/UserServiceTest.java
+++ b/whistle-on-backend/src/test/java/com/halaguys/whistleon/service/UserServiceTest.java
@@ -1,0 +1,5 @@
+package com.halaguys.whistleon.service;
+
+public class UserServiceTest {
+
+}


### PR DESCRIPTION
회원가입 및 중복확인 기능 구현.

id중복체크에서는 보통 HTTP 상태코드 409, Conflict를 주로 사용한다고 합니다.


대상 리소스의 현재 상태와 충돌하여 요청을 완료할 수 없음을 뜻합니다. 이 코드는 사용자가 충돌을 해결하고 다시 요청을 보낼 수 있을 때 적합합니다. 서버는 사용자가 충돌을 해결할 수 있도록 적합한 페이로드를 생성해야 합니다. PUT 요청에 대해 충돌할 가능성이 가장 높습니다.  예를 들어, 버전 지정이 사용 중이고 PUT인 표현에 이전(제3자) 요청에 의해 수행된 것과 상충되는 자원에 대한 변경사항이 포함된 경우, 원본 서버는 요청을 완료할 수 없음을 나타내기 위해 409 응답을 사용할 수 있습니다.

409 Conflict 코드는 리소스가 충돌이 발생하였고 사용자가 이를 반영할 수 있을 때 발생하는 상태 코드입니다. 아이디 중복 체크에서는 사용자가 충돌되지 않는 다른 아이디를 사용하여 충돌을 해결해야 하기 때문에 이 상태 코드도 적합하다고 생각하였습니다. 409 코드에 대하여 조사해보니 다른 웹 사이트에서도 ID 중복 발생 시 409 코드를 많이 쓴다고 현업자 분들의 의견이 달려있는 것을 확인하였습니다.


